### PR TITLE
Fixed existing commented out tests

### DIFF
--- a/src/PHPJasper.php
+++ b/src/PHPJasper.php
@@ -52,9 +52,9 @@ class PHPJasper
      * @return $this
      * @throws Exception\InvalidInputFile
      */
-    public function compile(string $input, string $output = '')
+    public function compile($input, string $output = '')
     {
-        if (!$input) {
+        if ( !$input ) {
             throw new \PHPJasper\Exception\InvalidInputFile();
         }
 

--- a/tests/PHPJasper/PHPJasperTest.php
+++ b/tests/PHPJasper/PHPJasperTest.php
@@ -17,10 +17,12 @@ final class PHPJasperTest extends TestCase
     private $PHPJasper;
     private $input;
     private $output;
+    protected $windows;
 
     public function setUp()
     {
         $this->PHPJasper = new PHPJasper();
+        $this->windows = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? true : false;
     }
 
     public function tearDown()
@@ -49,76 +51,81 @@ final class PHPJasperTest extends TestCase
         $this->assertEquals('jasperstarter list_parameters "{input_fille}"', $result->output());
     }
 
-    /*public function testCompileWithWrongInput()
+    public function testCompileWithWrongInput()
     {
-        $this->setExpectedExceptionFromAnnotation(\PHPJasper\Exception\InvalidInputFile::class);
+        $this->expectException(\PHPJasper\Exception\InvalidInputFile::class);
 
         $jasper = new PHPJasper();
-        $jasper->compile(null);
-    }*/
-    /*public function testCompileWithWrongInput()
-    {
-        $this->setExpectedException(\PHPJasper\Exception\InvalidInputFile::class);
-
-        $jasper = new PHPJasper();
+        
         $jasper->compile(null);
     }
 
-    public function testCompile()
+    public function testCompileHelloWorld()
     {
         $jasper = new PHPJasper();
+
         $result = $jasper->compile('hello_world.jrxml');
 
         $this->assertInstanceOf(PHPJasper::class, $result);
-        $this->assertEquals('./jasperstarter compile "hello_world.jrxml"', $result->output());
-    }
 
+        if($this->windows) {
+
+            $this->assertEquals('jasperstarter compile "hello_world.jrxml"', $result->output());
+        
+        }
+        else {
+
+            $this->assertEquals('./jasperstarter compile "hello_world.jrxml"', $result->output());
+        }
+
+    }
+    
     public function testExecuteWithoutCompile()
     {
-        $this->setExpectedException(\PHPJasper\Exception\InvalidCommandExecutable::class);
+        $this->expectException(\PHPJasper\Exception\InvalidCommandExecutable::class);
 
         $jasper = new PHPJasper();
         $jasper->execute();
     }
-
+    
     public function testExecuteWithCompile()
     {
-        $this->setExpectedException(\PHPJasper\Exception\ErrorCommandExecutable::class);
+        $this->expectException(\PHPJasper\Exception\ErrorCommandExecutable::class);
 
         $jasper = new PHPJasper();
         $jasper->compile('hello_world.jrxml')->execute();
     }
-
+    
     public function testListParametersWithWrongInput()
     {
-        $this->setExpectedException(\PHPJasper\Exception\InvalidInputFile::class);
+        $this->expectException(\PHPJasper\Exception\InvalidInputFile::class);
 
         $jasper = new PHPJasper();
         $jasper->listParameters('');
     }
-
+    
     public function testProcessWithWrongInput()
     {
-        $this->setExpectedException(\PHPJasper\Exception\InvalidInputFile::class);
+        $this->expectException(\PHPJasper\Exception\InvalidInputFile::class);
 
         $jasper = new PHPJasper();
-        $jasper->process(0);
+        $jasper->process(0, "");
     }
-
+    
     public function testProcessWithWrongFormat()
     {
-        $this->setExpectedException(\PHPJasper\Exception\InvalidFormat::class);
+        $this->expectException(\PHPJasper\Exception\InvalidFormat::class);
 
         $jasper = new PHPJasper();
         $jasper->process('hello_world.jrxml', false, [
             'format' => 'mp3'
         ]);
     }
-
+    
     public function testProcess()
     {
         $jasper = new PHPJasper();
-        $this->assertInstanceOf(PHPJasper::class, $jasper->process('hello_world.jrxml'));
-    }*/
+        $this->assertInstanceOf(PHPJasper::class, $jasper->process('hello_world.jrxml', ""));
+    }
 
 }


### PR DESCRIPTION
One part I wasn't sure about was the change to not type hinting input. PHP automatically grabs that and throws a TypeError before you even get to the InvalidInputFile. You could either catch the TypeError or drop the type hinting.