### PR TITLE
Workaround suggestion to resolve jasperstarter unsupported URL based JSON

### DIFF
--- a/src/Exception/NoJsonData.php
+++ b/src/Exception/NoJsonData.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace PHPJasper\Exception;
+
+use Exception;
+
+class NoJsonData extends Exception
+{
+    /**
+     * No Json Data constructor.
+     *
+     * @param string $message
+     * @param int $code
+     * @param Exception|null $previous
+     */
+    public function __construct($message = "", $code = 0, Exception $previous = null)
+    {
+        $message = 'No JSON data';
+        parent::__construct($message, $code, $previous);
+    }
+}


### PR DESCRIPTION
It's a workaround suggestion for the issue #46.

The `$options` value needs to be: 
````
$options = [
    'format' => ['pdf'],
    'params' => [],
    'locale' => 'en',
    'db_connection' => [
        'driver' => 'json_url',
        'data_file' => 'https://raw.githubusercontent.com/PHPJasper/phpjasper/master/examples/contacts.json',
        'json_query' => 'query'
    ]
];
````

I have never work with Jasper, but I tried to check if everything is ok with this implementation. Unfortunately, I couldn't generate a report because I stuck in the error:
````
Exception in thread "main" net.sf.jasperreports.engine.JRRuntimeException: Error initializing graphic environment.
````
This error happened in Jasper, so I think that everything is ok on PHP.
I will be grateful If you could please make a full test to be certain that everything is ok. 