### PR TITLE
Message for the error of PHPJasper->execute()

### DIFF
--- a/src/Exception/ErrorCommandExecutable.php
+++ b/src/Exception/ErrorCommandExecutable.php
@@ -14,7 +14,14 @@ class ErrorCommandExecutable extends Exception
      */
     public function __construct($message = "", $code = 0, Exception $previous = null)
     {
-        $message = 'Your report has an error and couldn \'t be processed!\ Try to output the command using the function `output();` and run it manually in the console.';
+        $message = trim($message);
+
+        if ($message === '') {
+            $message = 'Your report has an error and couldn \'t be processed!\ Try to output the command using the function `output();` and run it manually in the console.';
+        } else {
+            $message = 'Your report has an error and couldn \'t be processed!\ Try to output the command using the function `output();` and run it manually in the console. Error of the command: ' . $message;
+        }
+        
         parent::__construct($message, $code, $previous);
     }
 }

--- a/src/PHPJasper.php
+++ b/src/PHPJasper.php
@@ -79,6 +79,8 @@ class PHPJasper
             $this->command .= ' -o ' . "\"$output\"";
         }
 
+        $this->command .= " 2>&1";
+
         return $this;
     }
 
@@ -143,6 +145,8 @@ class PHPJasper
         if ($options['resources']) {
             $this->command .= " -r {$options['resources']}";
         }
+
+        $this->command .= " 2>&1";
 
         return $this;
     }
@@ -216,7 +220,8 @@ class PHPJasper
         chdir($this->pathExecutable);
         exec($this->command, $output, $returnVar);
         if ($returnVar !== 0) {
-            throw new \PHPJasper\Exception\ErrorCommandExecutable();
+            $message = implode(' ', $output);
+            throw new \PHPJasper\Exception\ErrorCommandExecutable($message);
         }
 
         return $output;


### PR DESCRIPTION
I propose to add the output of the error when executing the command of copying or generating a report so that it can be logged.

`$this->command .= " 2>&1";`
This message [https://stackoverflow.com/a/3099691](https://stackoverflow.com/a/3099691) says that in theory it should also work in Windows.