### PR TITLE
Added tests to improve code coverage to 100%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /vendor
 tests/*.jasper
+tests/fixture
 tests/codeCoverage
 
 # IDE


### PR DESCRIPTION
Hello,

First time contributing to an open source project, so any tips are welcome!
This is to resolve issue #171 
What's being added:
- fix on tests where the `output` method was being tested (assert doesn't test this method, since the `output` method doesn't return anything, instead it prints out the command being executed)
- test to check the command executed when `process` is called with `$options`
- test the `execute` with an user (there's an error while executing, may be some problem with docker container)
- test that the `execute` should throw an exception when the path executable is invalid