### PR TITLE
Fix return of method output

### DIFF
--- a/src/PHPJasper.php
+++ b/src/PHPJasper.php
@@ -229,7 +229,7 @@ class PHPJasper
      */
     public function output()
     {
-        print $this->command . "\n";
+        return $this->command . "\n";
     }
 
     /**


### PR DESCRIPTION
Docblock were annotated @return string, but method where printing result and returning void