### PR TITLE
PathExecutable parameterization

### DIFF
--- a/src/PHPJasper.php
+++ b/src/PHPJasper.php
@@ -72,10 +72,10 @@ class PHPJasper
     /**
      * PHPJasper constructor
      */
-    public function __construct()
+    public function __construct(string $pathExecutable = null)
     {
         $this->executable = 'jasperstarter';
-        $this->pathExecutable = __DIR__ . '/../bin/jasperstarter/bin';
+        $this->pathExecutable = $pathExecutable ?? __DIR__ . '/../bin/jasperstarter/bin';
         $this->windows = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? true : false;
     }
 


### PR DESCRIPTION
This change will allow the use of any version of Jasper installed on the server, with the default being to run the embedded version in the project. This will not cause bugs in projects that already use the tool.